### PR TITLE
angular events called twice after the first pjax call

### DIFF
--- a/angular-pjax.js
+++ b/angular-pjax.js
@@ -25,8 +25,10 @@
 
   angularPJAXModule.directive('pjaxContainer', function() {
     return {
+      scope:true,
       controller: ['$rootScope', '$scope', '$window', '$timeout', '$compile', '$element', function($rootScope, $scope, $window, $timeout, $compile, $element) {
-        var content, contentScope = null;
+        var contentScope = $scope,
+            parentScope = $scope.$parent;;
 
         var updateCurrentPath = function() {
           $rootScope.currentPath = $window.location.pathname;
@@ -54,7 +56,7 @@
           $timeout(function() {
             updateCurrentPath();
 
-            contentScope = $scope.$new(false, $scope);
+            contentScope = parentScope.$new(false, parentScope);
 
             $element.html($compile($element.html())(contentScope));
 


### PR DESCRIPTION
While performing the first pjax call event "**pjax:beforeReplace**" being called but the "contentScope" is equal to null and the scope is actually the closest scope to this directive her parent container (**scopeA** *see description below ) because this directive not providing any scope information.
```html
<div scopeA >
<div pjax-container ></div>
</div>
```
After "**pjax:end**" being called the $scope object equals to **scopeA** create new scope element and define itself as his parent

after compiling the new element and binding it with the new scope the hierarchy has changed to:
```html
<div scopeA >
<div scopeB pjax-container ></div>
</div>
```
so the first scope and his children never being destroyed.
and from now on on any pjax call we are destroying the new scope (**scopeB**).

Side effect:

Any scope that register to an angular event ``*.$on(..)`` will trigger twice after the first pjax call.
``$.on($destroy)`` not being called to any of the children scopes.

My fix creates a new scope and always destroy that scope so all the event being called .
also i handled the hierarchy issue by compiling the scope with the same parent each time.